### PR TITLE
fix(repo): creating custom schema flattener for docs

### DIFF
--- a/docs/angular/api-angular/executors/webpack-browser.md
+++ b/docs/angular/api-angular/executors/webpack-browser.md
@@ -14,17 +14,11 @@ A list of CommonJS packages that are allowed to be used without a build time war
 
 ### aot
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
 Build using Ahead of Time compilation.
-
-### assets
-
-Type: `array`
-
-List of static application assets.
 
 ### baseHref
 
@@ -32,15 +26,9 @@ Type: `string`
 
 Base url for the application being built.
 
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
-
 ### buildOptimizer
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -58,7 +46,7 @@ Default: `true`
 
 Type: `boolean`
 
-Use a separate bundle containing code used across multiple bundles.
+Generate a seperate bundle containing code used across multiple bundles.
 
 ### crossOrigin
 
@@ -84,67 +72,23 @@ Type: `string`
 
 URL where files will be deployed.
 
-### experimentalRollupPass
-
-Default: `false`
-
-Type: `boolean`
-
-Concatenate modules with Rollup before bundling them with Webpack.
-
-### extractCss
-
-Default: `false`
-
-Type: `boolean`
-
-Extract css from global styles into css files instead of js ones.
-
-### extractLicenses
-
-Default: `false`
-
-Type: `boolean`
-
-Extract all licenses in a separate file.
-
-### fileReplacements
-
-Type: `array`
-
-Replace compilation source files with other compilation source files in the build.
-
-### forkTypeChecker
+### ~~extractCss~~
 
 Default: `true`
 
 Type: `boolean`
 
-Run the TypeScript type checker in a forked process.
+**Deprecated:** Deprecated since version 11.0. No longer required to disable CSS extraction for HMR.
 
-### ~~i18nFile~~
+Extract CSS from global styles into '.css' files instead of '.js'.
 
-Type: `string`
+### extractLicenses
 
-**Deprecated:** Use 'locales' object in the project metadata instead.
+Default: `true`
 
-Localization file to use for i18n.
+Type: `boolean`
 
-### ~~i18nFormat~~
-
-Type: `string`
-
-**Deprecated:** No longer needed as the format will be determined automatically.
-
-Format of the localization file specified with --i18n-file.
-
-### ~~i18nLocale~~
-
-Type: `string`
-
-**Deprecated:** Use 'localize' instead.
-
-Locale to use for i18n.
+Extract all licenses in a separate file.
 
 ### i18nMissingTranslation
 
@@ -162,17 +106,21 @@ Type: `string`
 
 Configures the generation of the application's HTML index.
 
-### ~~lazyModules~~
+### inlineStyleLanguage
 
-Type: `array`
+Default: `css`
 
-**Deprecated:** 'SystemJsNgModuleLoader' is deprecated, and this is part of its usage. Use 'import()' syntax instead.
+Type: `string`
 
-List of additional NgModule files that will be lazy loaded. Lazy router modules will be discovered automatically.
+Possible values: `css`, `less`, `sass`, `scss`
+
+The stylesheet language to use for the application's inline component styles.
 
 ### localize
 
-Type: `boolean | boolean[] `
+Type: `boolean`
+
+Translate the bundles in one or more locales.
 
 ### main
 
@@ -182,7 +130,7 @@ The full path for the main entry point to the app, relative to the current works
 
 ### namedChunks
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
@@ -196,11 +144,11 @@ Path to ngsw-config.json.
 
 ### optimization
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
-Enables optimization of the build output.
+Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.
 
 ### outputHashing
 
@@ -240,6 +188,8 @@ Do not use the real path when resolving modules. If unset then will default to `
 
 ### progress
 
+Default: `true`
+
 Type: `boolean`
 
 Log progress to the console while building.
@@ -249,12 +199,6 @@ Log progress to the console while building.
 Type: `string`
 
 The path where style resources will be placed, relative to outputPath.
-
-### scripts
-
-Type: `array`
-
-Global scripts to be included in the build.
 
 ### serviceWorker
 
@@ -270,17 +214,17 @@ Default: `false`
 
 Type: `boolean`
 
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
+**Deprecated:** The recommended method to detect circular dependencies in project code is to use either a lint rule or other external tooling.
 
 Show circular dependency warnings on builds.
 
 ### sourceMap
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Output sourcemaps.
+Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.
 
 ### statsJson
 
@@ -289,12 +233,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.
-
-### styles
-
-Type: `array`
-
-Global styles to be included in the build.
 
 ### subresourceIntegrity
 
@@ -312,11 +250,11 @@ The full path for the TypeScript configuration file, relative to the current wor
 
 ### vendorChunk
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Use a separate bundle containing only vendor libraries.
+Generate a seperate bundle containing only vendor libraries. This option should only used for development.
 
 ### verbose
 

--- a/docs/angular/api-angular/generators/application.md
+++ b/docs/angular/api-angular/generators/application.md
@@ -50,14 +50,6 @@ Possible values: `protractor`, `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
-### enableIvy
-
-Default: `true`
-
-Type: `boolean`
-
-Create a new app that uses the Ivy rendering engine.
-
 ### inlineStyle
 
 Alias(es): s
@@ -84,7 +76,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/angular/api-angular/generators/library.md
+++ b/docs/angular/api-angular/generators/library.md
@@ -78,7 +78,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
@@ -157,16 +157,6 @@ Default: `false`
 Type: `boolean`
 
 Creates a library with stricter type checking and build optimization options.
-
-### style
-
-Default: `css`
-
-Type: `string`
-
-Possible values: `css`, `scss`, `styl`, `less`
-
-The file extension to be used for style files.
 
 ### tags
 

--- a/docs/angular/api-angular/generators/storybook-configuration.md
+++ b/docs/angular/api-angular/generators/storybook-configuration.md
@@ -60,7 +60,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/angular/api-linter/executors/lint.md
+++ b/docs/angular/api-linter/executors/lint.md
@@ -104,6 +104,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string | string[] `
+Type: `string`
 
 The name of the TypeScript configuration file.

--- a/docs/angular/api-next/executors/build.md
+++ b/docs/angular/api-next/executors/build.md
@@ -6,24 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
-
 ### nextConfig
 
 Type: `string`

--- a/docs/angular/api-node/executors/build.md
+++ b/docs/angular/api-node/executors/build.md
@@ -6,12 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### buildLibsFromSource
 
 Default: `true`
@@ -24,7 +18,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string | string[] `
+Type: `string`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 
@@ -35,24 +29,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### generatePackageJson
 
@@ -158,6 +134,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/docs/angular/api-node/executors/package.md
+++ b/docs/angular/api-node/executors/package.md
@@ -6,12 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static library assets.
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `dependencies`

--- a/docs/angular/api-storybook/generators/configuration.md
+++ b/docs/angular/api-storybook/generators/configuration.md
@@ -50,7 +50,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/angular/api-storybook/generators/cypress-project.md
+++ b/docs/angular/api-storybook/generators/cypress-project.md
@@ -44,7 +44,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/angular/api-web/executors/build.md
+++ b/docs/angular/api-web/executors/build.md
@@ -6,12 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### baseHref
 
 Default: `/`
@@ -19,12 +13,6 @@ Default: `/`
 Type: `string`
 
 Base url for the application being built.
-
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
 
 ### buildLibsFromSource
 
@@ -83,24 +71,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### index
 
@@ -178,12 +148,6 @@ Type: `boolean`
 
 Use a separate bundle containing the runtime.
 
-### scripts
-
-Type: `array`
-
-External Scripts which will be included before the main application entry
-
 ### ~~showCircularDependencies~~
 
 Default: `false`
@@ -209,12 +173,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
-
-### styles
-
-Type: `array`
-
-External Styles which will be included with the application
 
 ### subresourceIntegrity
 

--- a/docs/angular/api-web/executors/package.md
+++ b/docs/angular/api-web/executors/package.md
@@ -6,12 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### ~~babelConfig~~
 
 Type: `string`
@@ -58,24 +52,6 @@ Type: `boolean`
 
 CSS files will be extracted to the output folder.
 
-### globals
-
-Type: `object[]`
-
-A mapping of node modules to their UMD global names. Used by the UMD bundle
-
-#### moduleId
-
-Type: `string`
-
-The node module to map from (e.g. `react-dom`).
-
-#### global
-
-Type: `string`
-
-The global name to map to (e.g. `ReactDOM`).
-
 ### outputPath
 
 Type: `string`
@@ -90,7 +66,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/docs/angular/api-workspace/executors/run-commands.md
+++ b/docs/angular/api-workspace/executors/run-commands.md
@@ -182,10 +182,6 @@ Type: `string`
 
 Command to run in child process
 
-### commands
-
-Type: `array`
-
 ### cwd
 
 Type: `string`
@@ -200,7 +196,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string | string[] `
+Type: `string`
 
 Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.
 

--- a/docs/angular/api-workspace/executors/tsc.md
+++ b/docs/angular/api-workspace/executors/tsc.md
@@ -6,12 +6,6 @@ Properties can be configured in angular.json when defining the executor, or when
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### main
 
 Type: `string`

--- a/docs/node/api-angular/executors/webpack-browser.md
+++ b/docs/node/api-angular/executors/webpack-browser.md
@@ -15,17 +15,11 @@ A list of CommonJS packages that are allowed to be used without a build time war
 
 ### aot
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
 Build using Ahead of Time compilation.
-
-### assets
-
-Type: `array`
-
-List of static application assets.
 
 ### baseHref
 
@@ -33,15 +27,9 @@ Type: `string`
 
 Base url for the application being built.
 
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
-
 ### buildOptimizer
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -59,7 +47,7 @@ Default: `true`
 
 Type: `boolean`
 
-Use a separate bundle containing code used across multiple bundles.
+Generate a seperate bundle containing code used across multiple bundles.
 
 ### crossOrigin
 
@@ -85,67 +73,23 @@ Type: `string`
 
 URL where files will be deployed.
 
-### experimentalRollupPass
-
-Default: `false`
-
-Type: `boolean`
-
-Concatenate modules with Rollup before bundling them with Webpack.
-
-### extractCss
-
-Default: `false`
-
-Type: `boolean`
-
-Extract css from global styles into css files instead of js ones.
-
-### extractLicenses
-
-Default: `false`
-
-Type: `boolean`
-
-Extract all licenses in a separate file.
-
-### fileReplacements
-
-Type: `array`
-
-Replace compilation source files with other compilation source files in the build.
-
-### forkTypeChecker
+### ~~extractCss~~
 
 Default: `true`
 
 Type: `boolean`
 
-Run the TypeScript type checker in a forked process.
+**Deprecated:** Deprecated since version 11.0. No longer required to disable CSS extraction for HMR.
 
-### ~~i18nFile~~
+Extract CSS from global styles into '.css' files instead of '.js'.
 
-Type: `string`
+### extractLicenses
 
-**Deprecated:** Use 'locales' object in the project metadata instead.
+Default: `true`
 
-Localization file to use for i18n.
+Type: `boolean`
 
-### ~~i18nFormat~~
-
-Type: `string`
-
-**Deprecated:** No longer needed as the format will be determined automatically.
-
-Format of the localization file specified with --i18n-file.
-
-### ~~i18nLocale~~
-
-Type: `string`
-
-**Deprecated:** Use 'localize' instead.
-
-Locale to use for i18n.
+Extract all licenses in a separate file.
 
 ### i18nMissingTranslation
 
@@ -163,17 +107,21 @@ Type: `string`
 
 Configures the generation of the application's HTML index.
 
-### ~~lazyModules~~
+### inlineStyleLanguage
 
-Type: `array`
+Default: `css`
 
-**Deprecated:** 'SystemJsNgModuleLoader' is deprecated, and this is part of its usage. Use 'import()' syntax instead.
+Type: `string`
 
-List of additional NgModule files that will be lazy loaded. Lazy router modules will be discovered automatically.
+Possible values: `css`, `less`, `sass`, `scss`
+
+The stylesheet language to use for the application's inline component styles.
 
 ### localize
 
-Type: `boolean | boolean[] `
+Type: `boolean`
+
+Translate the bundles in one or more locales.
 
 ### main
 
@@ -183,7 +131,7 @@ The full path for the main entry point to the app, relative to the current works
 
 ### namedChunks
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
@@ -197,11 +145,11 @@ Path to ngsw-config.json.
 
 ### optimization
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
-Enables optimization of the build output.
+Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.
 
 ### outputHashing
 
@@ -241,6 +189,8 @@ Do not use the real path when resolving modules. If unset then will default to `
 
 ### progress
 
+Default: `true`
+
 Type: `boolean`
 
 Log progress to the console while building.
@@ -250,12 +200,6 @@ Log progress to the console while building.
 Type: `string`
 
 The path where style resources will be placed, relative to outputPath.
-
-### scripts
-
-Type: `array`
-
-Global scripts to be included in the build.
 
 ### serviceWorker
 
@@ -271,17 +215,17 @@ Default: `false`
 
 Type: `boolean`
 
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
+**Deprecated:** The recommended method to detect circular dependencies in project code is to use either a lint rule or other external tooling.
 
 Show circular dependency warnings on builds.
 
 ### sourceMap
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Output sourcemaps.
+Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.
 
 ### statsJson
 
@@ -290,12 +234,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.
-
-### styles
-
-Type: `array`
-
-Global styles to be included in the build.
 
 ### subresourceIntegrity
 
@@ -313,11 +251,11 @@ The full path for the TypeScript configuration file, relative to the current wor
 
 ### vendorChunk
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Use a separate bundle containing only vendor libraries.
+Generate a seperate bundle containing only vendor libraries. This option should only used for development.
 
 ### verbose
 

--- a/docs/node/api-angular/generators/application.md
+++ b/docs/node/api-angular/generators/application.md
@@ -50,14 +50,6 @@ Possible values: `protractor`, `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
-### enableIvy
-
-Default: `true`
-
-Type: `boolean`
-
-Create a new app that uses the Ivy rendering engine.
-
 ### inlineStyle
 
 Alias(es): s
@@ -84,7 +76,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/node/api-angular/generators/library.md
+++ b/docs/node/api-angular/generators/library.md
@@ -78,7 +78,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
@@ -157,16 +157,6 @@ Default: `false`
 Type: `boolean`
 
 Creates a library with stricter type checking and build optimization options.
-
-### style
-
-Default: `css`
-
-Type: `string`
-
-Possible values: `css`, `scss`, `styl`, `less`
-
-The file extension to be used for style files.
 
 ### tags
 

--- a/docs/node/api-angular/generators/storybook-configuration.md
+++ b/docs/node/api-angular/generators/storybook-configuration.md
@@ -60,7 +60,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/node/api-linter/executors/lint.md
+++ b/docs/node/api-linter/executors/lint.md
@@ -105,6 +105,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string | string[] `
+Type: `string`
 
 The name of the TypeScript configuration file.

--- a/docs/node/api-next/executors/build.md
+++ b/docs/node/api-next/executors/build.md
@@ -7,24 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
-
 ### nextConfig
 
 Type: `string`

--- a/docs/node/api-node/executors/build.md
+++ b/docs/node/api-node/executors/build.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### buildLibsFromSource
 
 Default: `true`
@@ -25,7 +19,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string | string[] `
+Type: `string`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 
@@ -36,24 +30,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### generatePackageJson
 
@@ -159,6 +135,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/docs/node/api-node/executors/package.md
+++ b/docs/node/api-node/executors/package.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static library assets.
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `dependencies`

--- a/docs/node/api-storybook/generators/configuration.md
+++ b/docs/node/api-storybook/generators/configuration.md
@@ -50,7 +50,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/node/api-storybook/generators/cypress-project.md
+++ b/docs/node/api-storybook/generators/cypress-project.md
@@ -44,7 +44,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/node/api-web/executors/build.md
+++ b/docs/node/api-web/executors/build.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### baseHref
 
 Default: `/`
@@ -20,12 +14,6 @@ Default: `/`
 Type: `string`
 
 Base url for the application being built.
-
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
 
 ### buildLibsFromSource
 
@@ -84,24 +72,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### index
 
@@ -179,12 +149,6 @@ Type: `boolean`
 
 Use a separate bundle containing the runtime.
 
-### scripts
-
-Type: `array`
-
-External Scripts which will be included before the main application entry
-
 ### ~~showCircularDependencies~~
 
 Default: `false`
@@ -210,12 +174,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
-
-### styles
-
-Type: `array`
-
-External Styles which will be included with the application
 
 ### subresourceIntegrity
 

--- a/docs/node/api-web/executors/package.md
+++ b/docs/node/api-web/executors/package.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### ~~babelConfig~~
 
 Type: `string`
@@ -59,24 +53,6 @@ Type: `boolean`
 
 CSS files will be extracted to the output folder.
 
-### globals
-
-Type: `object[]`
-
-A mapping of node modules to their UMD global names. Used by the UMD bundle
-
-#### moduleId
-
-Type: `string`
-
-The node module to map from (e.g. `react-dom`).
-
-#### global
-
-Type: `string`
-
-The global name to map to (e.g. `ReactDOM`).
-
 ### outputPath
 
 Type: `string`
@@ -91,7 +67,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/docs/node/api-workspace/executors/run-commands.md
+++ b/docs/node/api-workspace/executors/run-commands.md
@@ -183,10 +183,6 @@ Type: `string`
 
 Command to run in child process
 
-### commands
-
-Type: `array`
-
 ### cwd
 
 Type: `string`
@@ -201,7 +197,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string | string[] `
+Type: `string`
 
 Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.
 

--- a/docs/node/api-workspace/executors/tsc.md
+++ b/docs/node/api-workspace/executors/tsc.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/node/getti
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### main
 
 Type: `string`

--- a/docs/react/api-angular/executors/webpack-browser.md
+++ b/docs/react/api-angular/executors/webpack-browser.md
@@ -15,17 +15,11 @@ A list of CommonJS packages that are allowed to be used without a build time war
 
 ### aot
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
 Build using Ahead of Time compilation.
-
-### assets
-
-Type: `array`
-
-List of static application assets.
 
 ### baseHref
 
@@ -33,15 +27,9 @@ Type: `string`
 
 Base url for the application being built.
 
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
-
 ### buildOptimizer
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
@@ -59,7 +47,7 @@ Default: `true`
 
 Type: `boolean`
 
-Use a separate bundle containing code used across multiple bundles.
+Generate a seperate bundle containing code used across multiple bundles.
 
 ### crossOrigin
 
@@ -85,67 +73,23 @@ Type: `string`
 
 URL where files will be deployed.
 
-### experimentalRollupPass
-
-Default: `false`
-
-Type: `boolean`
-
-Concatenate modules with Rollup before bundling them with Webpack.
-
-### extractCss
-
-Default: `false`
-
-Type: `boolean`
-
-Extract css from global styles into css files instead of js ones.
-
-### extractLicenses
-
-Default: `false`
-
-Type: `boolean`
-
-Extract all licenses in a separate file.
-
-### fileReplacements
-
-Type: `array`
-
-Replace compilation source files with other compilation source files in the build.
-
-### forkTypeChecker
+### ~~extractCss~~
 
 Default: `true`
 
 Type: `boolean`
 
-Run the TypeScript type checker in a forked process.
+**Deprecated:** Deprecated since version 11.0. No longer required to disable CSS extraction for HMR.
 
-### ~~i18nFile~~
+Extract CSS from global styles into '.css' files instead of '.js'.
 
-Type: `string`
+### extractLicenses
 
-**Deprecated:** Use 'locales' object in the project metadata instead.
+Default: `true`
 
-Localization file to use for i18n.
+Type: `boolean`
 
-### ~~i18nFormat~~
-
-Type: `string`
-
-**Deprecated:** No longer needed as the format will be determined automatically.
-
-Format of the localization file specified with --i18n-file.
-
-### ~~i18nLocale~~
-
-Type: `string`
-
-**Deprecated:** Use 'localize' instead.
-
-Locale to use for i18n.
+Extract all licenses in a separate file.
 
 ### i18nMissingTranslation
 
@@ -163,17 +107,21 @@ Type: `string`
 
 Configures the generation of the application's HTML index.
 
-### ~~lazyModules~~
+### inlineStyleLanguage
 
-Type: `array`
+Default: `css`
 
-**Deprecated:** 'SystemJsNgModuleLoader' is deprecated, and this is part of its usage. Use 'import()' syntax instead.
+Type: `string`
 
-List of additional NgModule files that will be lazy loaded. Lazy router modules will be discovered automatically.
+Possible values: `css`, `less`, `sass`, `scss`
+
+The stylesheet language to use for the application's inline component styles.
 
 ### localize
 
-Type: `boolean | boolean[] `
+Type: `boolean`
+
+Translate the bundles in one or more locales.
 
 ### main
 
@@ -183,7 +131,7 @@ The full path for the main entry point to the app, relative to the current works
 
 ### namedChunks
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
@@ -197,11 +145,11 @@ Path to ngsw-config.json.
 
 ### optimization
 
-Default: `false`
+Default: `true`
 
 Type: `boolean`
 
-Enables optimization of the build output.
+Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration.
 
 ### outputHashing
 
@@ -241,6 +189,8 @@ Do not use the real path when resolving modules. If unset then will default to `
 
 ### progress
 
+Default: `true`
+
 Type: `boolean`
 
 Log progress to the console while building.
@@ -250,12 +200,6 @@ Log progress to the console while building.
 Type: `string`
 
 The path where style resources will be placed, relative to outputPath.
-
-### scripts
-
-Type: `array`
-
-Global scripts to be included in the build.
 
 ### serviceWorker
 
@@ -271,17 +215,17 @@ Default: `false`
 
 Type: `boolean`
 
-**Deprecated:** The recommended method to detect circular dependencies in project code is to use a either a lint rule or other external tooling.
+**Deprecated:** The recommended method to detect circular dependencies in project code is to use either a lint rule or other external tooling.
 
 Show circular dependency warnings on builds.
 
 ### sourceMap
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Output sourcemaps.
+Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration.
 
 ### statsJson
 
@@ -290,12 +234,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'.
-
-### styles
-
-Type: `array`
-
-Global styles to be included in the build.
 
 ### subresourceIntegrity
 
@@ -313,11 +251,11 @@ The full path for the TypeScript configuration file, relative to the current wor
 
 ### vendorChunk
 
-Default: `true`
+Default: `false`
 
 Type: `boolean`
 
-Use a separate bundle containing only vendor libraries.
+Generate a seperate bundle containing only vendor libraries. This option should only used for development.
 
 ### verbose
 

--- a/docs/react/api-angular/generators/application.md
+++ b/docs/react/api-angular/generators/application.md
@@ -50,14 +50,6 @@ Possible values: `protractor`, `cypress`, `none`
 
 Test runner to use for end to end (e2e) tests
 
-### enableIvy
-
-Default: `true`
-
-Type: `boolean`
-
-Create a new app that uses the Ivy rendering engine.
-
 ### inlineStyle
 
 Alias(es): s
@@ -84,7 +76,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/react/api-angular/generators/library.md
+++ b/docs/react/api-angular/generators/library.md
@@ -78,7 +78,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `tslint`, `eslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 
@@ -157,16 +157,6 @@ Default: `false`
 Type: `boolean`
 
 Creates a library with stricter type checking and build optimization options.
-
-### style
-
-Default: `css`
-
-Type: `string`
-
-Possible values: `css`, `scss`, `styl`, `less`
-
-The file extension to be used for style files.
 
 ### tags
 

--- a/docs/react/api-angular/generators/storybook-configuration.md
+++ b/docs/react/api-angular/generators/storybook-configuration.md
@@ -60,7 +60,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/react/api-linter/executors/lint.md
+++ b/docs/react/api-linter/executors/lint.md
@@ -105,6 +105,6 @@ Hide output text.
 
 ### tsConfig
 
-Type: `string | string[] `
+Type: `string`
 
 The name of the TypeScript configuration file.

--- a/docs/react/api-next/executors/build.md
+++ b/docs/react/api-next/executors/build.md
@@ -7,24 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
-
 ### nextConfig
 
 Type: `string`

--- a/docs/react/api-node/executors/build.md
+++ b/docs/react/api-node/executors/build.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### buildLibsFromSource
 
 Default: `true`
@@ -25,7 +19,7 @@ Read buildable libraries from source instead of building them separately.
 
 Default: `all`
 
-Type: `string | string[] `
+Type: `string`
 
 Dependencies to keep external to the bundle. ("all" (default), "none", or an array of module names)
 
@@ -36,24 +30,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### generatePackageJson
 
@@ -159,6 +135,6 @@ Run build when files change.
 
 ### webpackConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a webpack config, context and returns the resulting webpack config

--- a/docs/react/api-node/executors/package.md
+++ b/docs/react/api-node/executors/package.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static library assets.
-
 ### buildableProjectDepsInPackageJsonType
 
 Default: `dependencies`

--- a/docs/react/api-storybook/generators/configuration.md
+++ b/docs/react/api-storybook/generators/configuration.md
@@ -50,7 +50,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/react/api-storybook/generators/cypress-project.md
+++ b/docs/react/api-storybook/generators/cypress-project.md
@@ -44,7 +44,7 @@ Default: `eslint`
 
 Type: `string`
 
-Possible values: `eslint`, `tslint`
+Possible values: `eslint`, `tslint`, `none`
 
 The tool to use for running lint checks.
 

--- a/docs/react/api-web/executors/build.md
+++ b/docs/react/api-web/executors/build.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static application assets.
-
 ### baseHref
 
 Default: `/`
@@ -20,12 +14,6 @@ Default: `/`
 Type: `string`
 
 Base url for the application being built.
-
-### budgets
-
-Type: `array`
-
-Budget thresholds to ensure parts of your application stay within boundaries which you set.
 
 ### buildLibsFromSource
 
@@ -84,24 +72,6 @@ Default: `false`
 Type: `boolean`
 
 Extract all licenses in a separate file, in the case of production builds only.
-
-### fileReplacements
-
-Type: `object[]`
-
-Replace files with other files in the build.
-
-#### replace
-
-Type: `string`
-
-undefined
-
-#### with
-
-Type: `string`
-
-undefined
 
 ### index
 
@@ -179,12 +149,6 @@ Type: `boolean`
 
 Use a separate bundle containing the runtime.
 
-### scripts
-
-Type: `array`
-
-External Scripts which will be included before the main application entry
-
 ### ~~showCircularDependencies~~
 
 Default: `false`
@@ -210,12 +174,6 @@ Default: `false`
 Type: `boolean`
 
 Generates a 'stats.json' file which can be analyzed using tools such as: 'webpack-bundle-analyzer' or <https://webpack.github.io/analyse>.
-
-### styles
-
-Type: `array`
-
-External Styles which will be included with the application
 
 ### subresourceIntegrity
 

--- a/docs/react/api-web/executors/package.md
+++ b/docs/react/api-web/executors/package.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### ~~babelConfig~~
 
 Type: `string`
@@ -59,24 +53,6 @@ Type: `boolean`
 
 CSS files will be extracted to the output folder.
 
-### globals
-
-Type: `object[]`
-
-A mapping of node modules to their UMD global names. Used by the UMD bundle
-
-#### moduleId
-
-Type: `string`
-
-The node module to map from (e.g. `react-dom`).
-
-#### global
-
-Type: `string`
-
-The global name to map to (e.g. `ReactDOM`).
-
 ### outputPath
 
 Type: `string`
@@ -91,7 +67,7 @@ The path to package.json file.
 
 ### rollupConfig
 
-Type: `array[] | string `
+Type: `string`
 
 Path to a function which takes a rollup config and returns an updated rollup config
 

--- a/docs/react/api-workspace/executors/run-commands.md
+++ b/docs/react/api-workspace/executors/run-commands.md
@@ -183,10 +183,6 @@ Type: `string`
 
 Command to run in child process
 
-### commands
-
-Type: `array`
-
 ### cwd
 
 Type: `string`
@@ -201,7 +197,7 @@ You may specify a custom .env file path
 
 ### outputPath
 
-Type: `string | string[] `
+Type: `string`
 
 Allows you to specify where the build artifacts are stored. This allows Nx Cloud to pick them up correctly, in the case that the build artifacts are placed somewhere other than the top level dist folder.
 

--- a/docs/react/api-workspace/executors/tsc.md
+++ b/docs/react/api-workspace/executors/tsc.md
@@ -7,12 +7,6 @@ Read more about how to use executors and the CLI here: https://nx.dev/react/gett
 
 ## Properties
 
-### assets
-
-Type: `array`
-
-List of static assets.
-
 ### main
 
 Type: `string`

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -51,7 +51,7 @@ export default async function* storybookExecutor(
 
 function runInstance(options: StorybookExecutorOptions) {
   process.env.NODE_ENV = process.env.NODE_ENV ?? 'development';
-  return buildDevStandalone({ ...options, ci: true });
+  return buildDevStandalone({ ...options, ci: true } as any);
 }
 
 function storybookOptionMapper(

--- a/packages/storybook/src/generators/init/schema.json
+++ b/packages/storybook/src/generators/init/schema.json
@@ -1,7 +1,7 @@
 {
   "cli": "nx",
   "title": "Add Storybook Configuration to the workspace",
-  "$id": "Init Storybook Plugin",
+  "$id": "init-storybook-plugin",
   "type": "object",
   "properties": {
     "uiFramework": {

--- a/packages/workspace/src/core/file-utils.ts
+++ b/packages/workspace/src/core/file-utils.ts
@@ -268,7 +268,7 @@ export function readEnvironment(
   const workspaceJson = readWorkspaceJson();
   const workspaceResults = new WorkspaceResults(target, projects);
 
-  return { nxJson, workspaceJson, workspaceResults };
+  return { nxJson, workspaceJson, workspaceResults } as any;
 }
 
 export function normalizedProjectRoot(p: ProjectGraphNode): string {

--- a/packages/workspace/src/generators/move/lib/update-imports.ts
+++ b/packages/workspace/src/generators/move/lib/update-imports.ts
@@ -60,7 +60,7 @@ export function updateImports(
   if (schema.updateImportPath) {
     const replaceProjectRef = new RegExp(projectRef.from, 'g');
 
-    for (const [name, definition] of projects.entries()) {
+    for (const [name, definition] of Array.from(projects.entries())) {
       if (name === schema.projectName) {
         continue;
       }

--- a/packages/workspace/src/utilities/plugins/installed-plugins.ts
+++ b/packages/workspace/src/utilities/plugins/installed-plugins.ts
@@ -19,7 +19,7 @@ export function getInstalledPluginsFromPackageJson(
     ...Object.keys(packageJson.devDependencies || {}),
   ]);
 
-  return [...plugins]
+  return Array.from(plugins.values())
     .filter((name) => {
       try {
         // Check for `package.json` existence instead of requiring the module itself

--- a/scripts/documentation/schema-flattener.ts
+++ b/scripts/documentation/schema-flattener.ts
@@ -1,0 +1,40 @@
+import { deepCopy, json, schema } from '@angular-devkit/core';
+import { visitJsonSchema } from '@angular-devkit/core/src/json/schema';
+import * as Ajv from 'ajv';
+
+export interface SchemaFlattener {
+  flatten: (schema) => json.JsonObject;
+}
+
+export function createSchemaFlattener(
+  formats: schema.SchemaFormat[] = []
+): SchemaFlattener {
+  const ajv = new Ajv();
+  for (const format of formats) {
+    ajv.addFormat(format.name, format.formatter as any);
+  }
+  return {
+    flatten: (schema) => {
+      const validate = ajv.removeSchema(schema).compile(schema);
+      const self = this;
+      function visitor(current, pointer, parentSchema, index) {
+        if (
+          current &&
+          parentSchema &&
+          index &&
+          json.isJsonObject(current) &&
+          current.hasOwnProperty('$ref') &&
+          typeof current['$ref'] == 'string'
+        ) {
+          const resolved = self._resolver(current['$ref'], validate);
+          if (resolved.schema) {
+            parentSchema[index] = resolved.schema;
+          }
+        }
+      }
+      const schemaCopy = deepCopy(validate.schema) as json.JsonObject;
+      visitJsonSchema(schemaCopy, visitor);
+      return schemaCopy;
+    },
+  };
+}


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
Documentation generation fails after upgrading to Angular 12's devkit

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Documentation is generated as before; Nx breaks from usage of devkit's `CoreSchemaRegistry` in favor of our own `SchemaFlattener` implementation.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
