### PR TITLE
feat(angular): add app config for standalone component apps

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -188,6 +188,15 @@
       },
       "description": "Update the @angular/cli package version to ~16.0.0-rc.1.",
       "factory": "./src/migrations/update-16-1-0/update-angular-cli"
+    },
+    "extract-app-config-for-standalone": {
+      "cli": "nx",
+      "version": "16.1.0-beta.0",
+      "requires": {
+        "@angular/core": ">=16.0.0-rc.1"
+      },
+      "description": "Extract the app config for standalone apps",
+      "factory": "./src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
+++ b/packages/angular/src/generators/application/__snapshots__/application.spec.ts.snap
@@ -208,27 +208,37 @@ exports[`app --minimal should skip "nx-welcome.component.ts" file and references
 
 exports[`app --standalone should generate a standalone app correctly with routing 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
-import { appRoutes } from './app/app.routes';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
-}).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
 "
 `;
 
 exports[`app --standalone should generate a standalone app correctly with routing 2`] = `
+"import { ApplicationConfig } from '@angular/core';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+} from '@angular/router';
+import { appRoutes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+};
+"
+`;
+
+exports[`app --standalone should generate a standalone app correctly with routing 3`] = `
 "import { Route } from '@angular/router';
 
 export const appRoutes: Route[] = [];
 "
 `;
 
-exports[`app --standalone should generate a standalone app correctly with routing 3`] = `
+exports[`app --standalone should generate a standalone app correctly with routing 4`] = `
 "import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { NxWelcomeComponent } from './nx-welcome.component';
@@ -246,7 +256,7 @@ export class AppComponent {
 "
 `;
 
-exports[`app --standalone should generate a standalone app correctly with routing 4`] = `
+exports[`app --standalone should generate a standalone app correctly with routing 5`] = `
 "import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
@@ -279,15 +289,25 @@ describe('AppComponent', () => {
 
 exports[`app --standalone should generate a standalone app correctly without routing 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {
-  providers: [],
-}).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
 "
 `;
 
 exports[`app --standalone should generate a standalone app correctly without routing 2`] = `
+"import { ApplicationConfig } from '@angular/core';
+
+export const appConfig: ApplicationConfig = {
+  providers: [],
+};
+"
+`;
+
+exports[`app --standalone should generate a standalone app correctly without routing 3`] = `
 "import { Component } from '@angular/core';
 import { NxWelcomeComponent } from './nx-welcome.component';
 
@@ -304,7 +324,7 @@ export class AppComponent {
 "
 `;
 
-exports[`app --standalone should generate a standalone app correctly without routing 3`] = `
+exports[`app --standalone should generate a standalone app correctly without routing 4`] = `
 "import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';

--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -748,6 +748,9 @@ describe('app', () => {
         appTree.read('apps/standalone/src/main.ts', 'utf-8')
       ).toMatchSnapshot();
       expect(
+        appTree.read('apps/standalone/src/app/app.config.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
         appTree.read('apps/standalone/src/app/app.routes.ts', 'utf-8')
       ).toMatchSnapshot();
       expect(
@@ -774,6 +777,9 @@ describe('app', () => {
       // ASSERT
       expect(
         appTree.read('apps/standalone/src/main.ts', 'utf-8')
+      ).toMatchSnapshot();
+      expect(
+        appTree.read('apps/standalone/src/app/app.config.ts', 'utf-8')
       ).toMatchSnapshot();
       expect(
         appTree.read('apps/standalone/src/app/app.component.ts', 'utf-8')

--- a/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/app/app.config.ts__tpl__
@@ -1,0 +1,7 @@
+import { ApplicationConfig } from '@angular/core';<% if (routing) { %>
+import { provideRouter, withEnabledBlockingInitialNavigation } from '@angular/router';
+import { appRoutes } from './app.routes';<% } %>
+
+export const appConfig: ApplicationConfig = {
+  providers: [<% if (routing) { %>provideRouter(appRoutes, withEnabledBlockingInitialNavigation()) <% } %>]
+};

--- a/packages/angular/src/generators/application/files/standalone-components/src/main.ts__tpl__
+++ b/packages/angular/src/generators/application/files/standalone-components/src/main.ts__tpl__
@@ -1,11 +1,5 @@
-import { bootstrapApplication } from '@angular/platform-browser';<% if(routing) { %>
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
-import { appRoutes } from './app/app.routes';<% } %>
+import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {
-  providers: [<% if(routing) { %>provideRouter(appRoutes, withEnabledBlockingInitialNavigation())<% } %>],
-}).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) => console.error(err));

--- a/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
+++ b/packages/angular/src/generators/host/__snapshots__/host.spec.ts.snap
@@ -226,16 +226,12 @@ module.exports = withModuleFederation(config);
 
 exports[`Host App Generator should generate a host with remotes using standalone components 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
-import {
-  provideRouter,
-  withEnabledBlockingInitialNavigation,
-} from '@angular/router';
-import { appRoutes } from './app/app.routes';
+import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, {
-  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
-}).catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
 "
 `;
 

--- a/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
+++ b/packages/angular/src/generators/ngrx/__snapshots__/ngrx.spec.ts.snap
@@ -658,18 +658,28 @@ export const appRoutes: Routes = [
 
 exports[`ngrx Standalone APIs should add a root module with feature module when minimal is set to false 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
+"
+`;
+
+exports[`ngrx Standalone APIs should add a root module with feature module when minimal is set to false 2`] = `
+"import { ApplicationConfig } from '@angular/core';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
-import { appRoutes } from './app/app.routes';
-import { AppComponent } from './app/app.component';
+import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 import * as fromUsers from './+state/users.reducer';
 import { UsersEffects } from './+state/users.effects';
 
-bootstrapApplication(AppComponent, {
+export const appConfig: ApplicationConfig = {
   providers: [
     provideEffects(UsersEffects),
     provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
@@ -677,46 +687,66 @@ bootstrapApplication(AppComponent, {
     provideStore(),
     provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
   ],
-}).catch((err) => console.error(err));
+};
 "
 `;
 
 exports[`ngrx Standalone APIs should add an empty provideStore when minimal and root are set to true 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
+"
+`;
+
+exports[`ngrx Standalone APIs should add an empty provideStore when minimal and root are set to true 2`] = `
+"import { ApplicationConfig } from '@angular/core';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
-import { appRoutes } from './app/app.routes';
-import { AppComponent } from './app/app.component';
+import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 
-bootstrapApplication(AppComponent, {
+export const appConfig: ApplicationConfig = {
   providers: [
     provideEffects(),
     provideStore(),
     provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
   ],
-}).catch((err) => console.error(err));
+};
 "
 `;
 
 exports[`ngrx Standalone APIs should add facade provider when facade is true 1`] = `
 "import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);
+"
+`;
+
+exports[`ngrx Standalone APIs should add facade provider when facade is true 2`] = `
+"import { ApplicationConfig } from '@angular/core';
 import {
   provideRouter,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
-import { appRoutes } from './app/app.routes';
-import { AppComponent } from './app/app.component';
+import { appRoutes } from './app.routes';
 import { provideStore, provideState } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 import * as fromUsers from './+state/users.reducer';
 import { UsersEffects } from './+state/users.effects';
 import { UsersFacade } from './+state/users.facade';
 
-bootstrapApplication(AppComponent, {
+export const appConfig: ApplicationConfig = {
   providers: [
     provideEffects(UsersEffects),
     provideState(fromUsers.USERS_FEATURE_KEY, fromUsers.usersReducer),
@@ -725,7 +755,7 @@ bootstrapApplication(AppComponent, {
     UsersFacade,
     provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
   ],
-}).catch((err) => console.error(err));
+};
 "
 `;
 

--- a/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
+++ b/packages/angular/src/generators/ngrx/lib/add-imports-to-module.ts
@@ -5,7 +5,7 @@ import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript'
 import type { SourceFile } from 'typescript';
 import {
   addImportToModule,
-  addProviderToBootstrapApplication,
+  addProviderToAppConfig,
   addProviderToModule,
 } from '../../../utils/nx-devkit/ast-utils';
 import type { NormalizedNgRxGeneratorOptions } from './normalize-options';
@@ -23,8 +23,8 @@ function addRootStoreImport(
   storeForRoot: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('bootstrapApplication')) {
-      addProviderToBootstrapApplication(tree, parentPath, provideRootStore);
+    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+      addProviderToAppConfig(tree, parentPath, provideRootStore);
     } else {
       addProviderToRoute(tree, parentPath, route, provideRootStore);
     }
@@ -44,8 +44,8 @@ function addRootEffectsImport(
   effectsForEmptyRoot: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('bootstrapApplication')) {
-      addProviderToBootstrapApplication(tree, parentPath, provideRootEffects);
+    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+      addProviderToAppConfig(tree, parentPath, provideRootEffects);
     } else {
       addProviderToRoute(tree, parentPath, route, provideRootEffects);
     }
@@ -91,12 +91,8 @@ function addStoreForFeatureImport(
   storeForFeature: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('bootstrapApplication')) {
-      addProviderToBootstrapApplication(
-        tree,
-        parentPath,
-        provideStoreForFeature
-      );
+    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+      addProviderToAppConfig(tree, parentPath, provideStoreForFeature);
     } else {
       addProviderToRoute(tree, parentPath, route, provideStoreForFeature);
     }
@@ -121,12 +117,8 @@ function addEffectsForFeatureImport(
   effectsForFeature: string
 ) {
   if (isParentStandalone) {
-    if (tree.read(parentPath, 'utf-8').includes('bootstrapApplication')) {
-      addProviderToBootstrapApplication(
-        tree,
-        parentPath,
-        provideEffectsForFeature
-      );
+    if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+      addProviderToAppConfig(tree, parentPath, provideEffectsForFeature);
     } else {
       addProviderToRoute(tree, parentPath, route, provideEffectsForFeature);
     }
@@ -257,8 +249,8 @@ export function addImportsToModule(
       if (options.facade) {
         sourceFile = addImport(sourceFile, facadeName, facadePath);
         if (isParentStandalone) {
-          if (tree.read(parentPath, 'utf-8').includes('bootstrapApplication')) {
-            addProviderToBootstrapApplication(tree, parentPath, facadeName);
+          if (tree.read(parentPath, 'utf-8').includes('ApplicationConfig')) {
+            addProviderToAppConfig(tree, parentPath, facadeName);
           } else {
             addProviderToRoute(tree, parentPath, options.route, facadeName);
           }

--- a/packages/angular/src/generators/ngrx/ngrx.spec.ts
+++ b/packages/angular/src/generators/ngrx/ngrx.spec.ts
@@ -30,7 +30,7 @@ describe('ngrx', () => {
   const defaultStandaloneOptions: NgRxGeneratorOptions = {
     directory: '+state',
     minimal: true,
-    parent: 'apps/my-app/src/main.ts',
+    parent: 'apps/my-app/src/app/app.config.ts',
     name: 'users',
   };
 
@@ -534,6 +534,9 @@ describe('ngrx', () => {
       });
 
       expect(tree.read('/apps/my-app/src/main.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('/apps/my-app/src/app/app.config.ts', 'utf-8')
+      ).toMatchSnapshot();
       expect(tree.exists('/apps/my-app/src/app/+state/users.actions.ts')).toBe(
         false
       );
@@ -562,6 +565,9 @@ describe('ngrx', () => {
       });
 
       expect(tree.read('/apps/my-app/src/main.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('/apps/my-app/src/app/app.config.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should add a feature module when route is undefined', async () => {
@@ -619,6 +625,9 @@ describe('ngrx', () => {
       });
 
       expect(tree.read('/apps/my-app/src/main.ts', 'utf-8')).toMatchSnapshot();
+      expect(
+        tree.read('/apps/my-app/src/app/app.config.ts', 'utf-8')
+      ).toMatchSnapshot();
     });
 
     it('should add facade provider when facade is true and --root is false', async () => {

--- a/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.spec.ts
+++ b/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.spec.ts
@@ -1,0 +1,123 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import extractStandaloneConfig from './extract-standalone-config-from-bootstrap';
+import { addProjectConfiguration } from '@nx/devkit';
+
+const TEST_MAIN_FILE = `import { bootstrapApplication } from '@angular/platform-browser';
+import {
+  provideRouter,
+  withEnabledBlockingInitialNavigation,
+} from '@angular/router';
+import { appRoutes } from './app/app.routes';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+}).catch((err) => console.error(err));`;
+
+describe('extractStandaloneConfigFromBootstrap', () => {
+  it('should extract the config correctly from a standard main.ts file', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', {
+      name: 'app1',
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      projectType: 'application',
+      targets: {
+        build: {
+          options: {
+            main: 'apps/app1/src/main.ts',
+          },
+        },
+      },
+    });
+
+    tree.write('apps/app1/src/main.ts', TEST_MAIN_FILE);
+
+    // ACT
+    await extractStandaloneConfig(tree);
+
+    // ASSERT
+    expect(tree.read('apps/app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { appConfig } from './app/app.config';
+      import { bootstrapApplication } from '@angular/platform-browser';
+
+      import { AppComponent } from './app/app.component';
+
+      bootstrapApplication(AppComponent, appConfig).catch((err) =>
+        console.error(err)
+      );
+      "
+    `);
+    expect(tree.exists('apps/app1/src/app/app.config.ts')).toBeTruthy();
+    expect(tree.read('apps/app1/src/app/app.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { ApplicationConfig } from '@angular/core';
+      import {
+        provideRouter,
+        withEnabledBlockingInitialNavigation,
+      } from '@angular/router';
+      import { appRoutes } from './app/app.routes';
+      export const appConfig: ApplicationConfig = {
+        providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+      };
+      "
+    `);
+  });
+
+  it('should extract the config correctly when the main.ts imports bootstrap from bootstrap.ts file', async () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'app1', {
+      name: 'app1',
+      root: 'apps/app1',
+      sourceRoot: 'apps/app1/src',
+      projectType: 'application',
+      targets: {
+        build: {
+          options: {
+            main: 'apps/app1/src/main.ts',
+          },
+        },
+      },
+    });
+
+    tree.write('apps/app1/src/main.ts', `import('./bootstrap');`);
+    tree.write('apps/app1/src/bootstrap.ts', TEST_MAIN_FILE);
+
+    // ACT
+    await extractStandaloneConfig(tree);
+
+    // ASSERT
+    expect(tree.read('apps/app1/src/main.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import('./bootstrap');
+      "
+    `);
+    expect(tree.read('apps/app1/src/bootstrap.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { appConfig } from './app/app.config';
+      import { bootstrapApplication } from '@angular/platform-browser';
+
+      import { AppComponent } from './app/app.component';
+
+      bootstrapApplication(AppComponent, appConfig).catch((err) =>
+        console.error(err)
+      );
+      "
+    `);
+    expect(tree.exists('apps/app1/src/app/app.config.ts')).toBeTruthy();
+    expect(tree.read('apps/app1/src/app/app.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { ApplicationConfig } from '@angular/core';
+      import {
+        provideRouter,
+        withEnabledBlockingInitialNavigation,
+      } from '@angular/router';
+      import { appRoutes } from './app/app.routes';
+      export const appConfig: ApplicationConfig = {
+        providers: [provideRouter(appRoutes, withEnabledBlockingInitialNavigation())],
+      };
+      "
+    `);
+  });
+});

--- a/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.ts
+++ b/packages/angular/src/migrations/update-16-1-0/extract-standalone-config-from-bootstrap.ts
@@ -1,0 +1,191 @@
+import type { ProjectConfiguration, Tree } from '@nx/devkit';
+import { formatFiles, getProjects, joinPathFragments } from '@nx/devkit';
+import type { Node, SourceFile } from 'typescript';
+import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
+
+let tsModule: typeof import('typescript');
+let tsquery: typeof import('@phenomnomnominal/tsquery').tsquery;
+
+function getBootstrapCallFileInfo<T>(
+  project: ProjectConfiguration,
+  tree: Tree
+) {
+  const IMPORT_BOOTSTRAP_FILE =
+    'CallExpression:has(ImportKeyword) > StringLiteral';
+
+  let bootstrapCallFilePath = project.targets?.build?.options?.main;
+  let bootstrapCallFileContents = tree.read(bootstrapCallFilePath, 'utf-8');
+
+  const ast = tsquery.ast(bootstrapCallFileContents);
+  const importBootstrapNodes = tsquery(ast, IMPORT_BOOTSTRAP_FILE, {
+    visitAllChildren: true,
+  });
+
+  if (
+    importBootstrapNodes.length > 0 &&
+    importBootstrapNodes[0].getText().includes('./bootstrap')
+  ) {
+    bootstrapCallFilePath = joinPathFragments(
+      project.sourceRoot,
+      'bootstrap.ts'
+    );
+    bootstrapCallFileContents = tree.read(bootstrapCallFilePath, 'utf-8');
+  }
+  return { bootstrapCallFilePath, bootstrapCallFileContents };
+}
+
+function getImportTokenMap(bootstrapCallFileContentsAst: SourceFile) {
+  const importTokenMap = new Map<string, string>();
+  const importedTokensNodes = tsquery(
+    bootstrapCallFileContentsAst,
+    'ImportDeclaration > ImportClause',
+    { visitAllChildren: true }
+  );
+
+  for (const node of importedTokensNodes) {
+    importTokenMap.set(node.getText(), node.parent.getText());
+  }
+  return importTokenMap;
+}
+
+function getImportsRequiredForAppConfig(
+  importTokenMap: Map<string, string>,
+  appConfigNode: Node
+) {
+  const importsRequiredForAppConfig = new Set<string>();
+  const checkImportsForTokens = (nodeText: string) => {
+    const keys = importTokenMap.keys();
+    for (const key of keys) {
+      if (key.includes(nodeText))
+        importsRequiredForAppConfig.add(importTokenMap.get(key));
+    }
+  };
+  const visitEachChild = (node: Node) => {
+    node.forEachChild((node) => {
+      const nodeText = node.getText();
+      checkImportsForTokens(nodeText);
+      visitEachChild(node);
+    });
+  };
+  visitEachChild(appConfigNode);
+  return importsRequiredForAppConfig;
+}
+
+function getAppConfigFileContents(
+  importsRequiredForAppConfig: Set<string>,
+  appConfigText: string
+) {
+  const buildAppConfigFileContents = (
+    importStatements: string[],
+    appConfig: string
+  ) => `import { ApplicationConfig } from '@angular/core';${importStatements.join(
+    '\n'
+  )}
+        export const appConfig: ApplicationConfig = ${appConfig}`;
+
+  const appConfigFileContents = buildAppConfigFileContents(
+    Array.from(importsRequiredForAppConfig),
+    appConfigText
+  );
+  return appConfigFileContents;
+}
+
+function getBootstrapCallFileContents(
+  bootstrapCallFileContents: string,
+  appConfigNode: Node,
+  importsRequiredForAppConfig: Set<string>
+) {
+  let newBootstrapCallFileContents = `import { appConfig } from './app/app.config';
+${bootstrapCallFileContents.slice(
+  0,
+  appConfigNode.getStart()
+)}appConfig${bootstrapCallFileContents.slice(appConfigNode.getEnd())}`;
+
+  for (const importStatement of importsRequiredForAppConfig) {
+    newBootstrapCallFileContents = newBootstrapCallFileContents.replace(
+      importStatement,
+      ''
+    );
+  }
+  return newBootstrapCallFileContents;
+}
+
+export default async function extractStandaloneConfig(tree: Tree) {
+  if (!tsModule) {
+    tsModule = ensureTypescript();
+  }
+  if (!tsquery) {
+    tsquery = require('@phenomnomnominal/tsquery').tsquery;
+  }
+
+  const projects = getProjects(tree);
+
+  const BOOTSTRAP_APPLICATION_CALL_SELECTOR =
+    'CallExpression:has(Identifier[name=bootstrapApplication])';
+  const BOOTSTRAP_APPLICATION_CALL_CONFIG_SELECTOR =
+    'CallExpression:has(Identifier[name=bootstrapApplication]) > ObjectLiteralExpression';
+
+  for (const [projectName, project] of projects.entries()) {
+    if (project.projectType !== 'application') {
+      continue;
+    }
+    if (project.targets?.build?.options?.main === undefined) {
+      continue;
+    }
+
+    const { bootstrapCallFilePath, bootstrapCallFileContents } =
+      getBootstrapCallFileInfo(project, tree);
+
+    const bootstrapCallFileContentsAst = tsquery.ast(bootstrapCallFileContents);
+    const nodes: Node[] = tsquery(
+      bootstrapCallFileContentsAst,
+      BOOTSTRAP_APPLICATION_CALL_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (nodes.length === 0) {
+      continue;
+    }
+
+    const importTokenMap = getImportTokenMap(bootstrapCallFileContentsAst);
+
+    const bootstrapCallNode = nodes[0];
+    const appConfigNodes = tsquery(
+      bootstrapCallNode,
+      BOOTSTRAP_APPLICATION_CALL_CONFIG_SELECTOR,
+      { visitAllChildren: true }
+    );
+    if (appConfigNodes.length === 0) {
+      continue;
+    }
+
+    const appConfigNode = appConfigNodes[0];
+    const appConfigText = appConfigNode.getText();
+
+    const importsRequiredForAppConfig = getImportsRequiredForAppConfig(
+      importTokenMap,
+      appConfigNode
+    );
+
+    const appConfigFilePath = joinPathFragments(
+      project.sourceRoot,
+      'app/app.config.ts'
+    );
+
+    const appConfigFileContents = getAppConfigFileContents(
+      importsRequiredForAppConfig,
+      appConfigText
+    );
+
+    tree.write(appConfigFilePath, appConfigFileContents);
+
+    let newBootstrapCallFileContents = getBootstrapCallFileContents(
+      bootstrapCallFileContents,
+      appConfigNode,
+      importsRequiredForAppConfig
+    );
+
+    tree.write(bootstrapCallFilePath, newBootstrapCallFileContents);
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/angular/src/utils/nx-devkit/ast-utils.spec.ts
+++ b/packages/angular/src/utils/nx-devkit/ast-utils.spec.ts
@@ -3,6 +3,7 @@ import {
   addImportToDirective,
   addImportToModule,
   addImportToPipe,
+  addProviderToAppConfig,
   addProviderToBootstrapApplication,
   isStandalone,
 } from './ast-utils';
@@ -300,6 +301,37 @@ bootstrapApplication(AppComponent, {
           provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
         ],
       }).catch((err) => console.error(err));"
+    `);
+  });
+
+  it('should add a provider to the appConfig', () => {
+    // ARRANGE
+    const tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    tree.write(
+      'app.config.ts',
+      `import { ApplicationConfig } from '@angular/core';
+import { provideRouter } from '@angular/router';
+
+import { routes } from './app.routes';
+
+export const appConfig: ApplicationConfig = {
+  providers: [provideRouter(routes) ]
+};`
+    );
+
+    // ACT
+    addProviderToAppConfig(tree, 'app.config.ts', 'provideStore()');
+
+    // ASSERT
+    expect(tree.read('app.config.ts', 'utf-8')).toMatchInlineSnapshot(`
+      "import { ApplicationConfig } from '@angular/core';
+      import { provideRouter } from '@angular/router';
+
+      import { routes } from './app.routes';
+
+      export const appConfig: ApplicationConfig = {
+        providers: [provideStore(),provideRouter(routes) ]
+      };"
     `);
   });
 });

--- a/packages/angular/src/utils/public-api.ts
+++ b/packages/angular/src/utils/public-api.ts
@@ -5,6 +5,7 @@ export {
   addImportToPipe,
   addImportToModule,
   addProviderToBootstrapApplication,
+  addProviderToAppConfig,
   addProviderToComponent,
   addProviderToModule,
 } from './nx-devkit/ast-utils';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->
We do not generate an appConfig file similar to Angular app schematic

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
We don't necessarily need this just for application generation, however SSR will merge the CSR providers at root level with the serverConfig at server level, and this pattern provides a convenient method of extracting that config.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
